### PR TITLE
Fix method call in the readme/usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ class Program
 {
     static void main(string[] args)
 	{
-		Console.WriteLine(Ipify.GetAddress());
+		Console.WriteLine(Ipify.GetPublicAddress());
 	}
 }
 ```


### PR DESCRIPTION
`Ipify.GetAddress()` has been replaced by `Ipify.GetPublicAddress()`
This commit updates the readme to reflect that change.

(Addresses #2)
