### PR TITLE
Disposes of WebClient properly, more security, and improved documentation.

### DIFF
--- a/src/Ipify.Tests/IpifyTests.cs
+++ b/src/Ipify.Tests/IpifyTests.cs
@@ -15,17 +15,13 @@ namespace Ipify.Tests
         [Test]
         public void GetAddress_ReturnsStringContainingAnIPAddress()
         {
-            string ip = Ipify.GetPublicAddress();
-            IPAddress ipAddress;
-            Assert.IsTrue(IPAddress.TryParse(ip, out ipAddress));
+            Assert.IsTrue(IPAddress.TryParse(Ipify.GetPublicIPAddressString(), out _));
         }
 
         [Test]
-        public void GetAddress_ReturnsStringContainingAnIPAddressUsingHttps()
+        public void GetAddress_ReturnsStringContainingAnIPAddressUsingHttp()
         {
-            string ip = Ipify.GetPublicAddress(true);
-            IPAddress ipAddress;
-            Assert.IsTrue(IPAddress.TryParse(ip, out ipAddress));
+            Assert.IsTrue(IPAddress.TryParse(Ipify.GetPublicIPAddressString(false), out _));
         }
 
         [Test]
@@ -37,9 +33,9 @@ namespace Ipify.Tests
         }
 
         [Test]
-        public void GetIPAddress_ReturnsIPAddressInstanceUsingHttps()
+        public void GetIPAddress_ReturnsIPAddressInstanceUsingHttp()
         {
-            IPAddress ipAddress = Ipify.GetPublicIPAddress(true);
+            IPAddress ipAddress = Ipify.GetPublicIPAddress(false);
             Assert.IsNotNull(ipAddress);
             Assert.AreNotEqual(IPAddress.None, ipAddress);
         }

--- a/src/Ipify/Ipify.cs
+++ b/src/Ipify/Ipify.cs
@@ -14,27 +14,29 @@ namespace Ipify
     public static class Ipify
     {
         /// <summary>
-        /// Resolves the public IP address and returns it as a string.
+        /// Resolves the public IP address and returns it as a <see cref="string"/>.
         /// </summary>
         /// <param name="useHttps">
         /// Specifies whether to use HTTPS to talk to ipify.org (defaults to
-        /// <b>false</b> if omitted).
+        /// <b>true</b> if omitted).
         /// </param>
         /// <returns>
-        /// A string containing the IP address, or an empty string if an error is
+        /// A <see cref="string"/> containing the public IP address, or <see cref="string.Empty"/> if an error is
         /// encountered.
         /// </returns>
-        public static string GetPublicAddress(bool useHttps = false)
+        public static string GetPublicIPAddressString(bool useHttps = true)
         {
             var endpoint = useHttps ? "https://api.ipify.org" : "http://api.ipify.org";
-            WebClient client = new WebClient();
-            try
+            using (var client = new WebClient())
             {
-                return client.DownloadString(endpoint);
-            }
-            catch
-            {
-                return string.Empty;
+                try
+                {
+                    return client.DownloadString(endpoint);
+                }
+                catch
+                {
+                    return string.Empty;
+                }
             }
         }
 
@@ -44,22 +46,21 @@ namespace Ipify
         /// </summary>
         /// <param name="useHttps">
         /// Specifies whether to use HTTPS to talk to ipify.org (defaults to
-        /// <b>false</b> if omitted).
+        /// <b>true</b> if omitted).
         /// </param>
         /// <returns>
-        /// An instance of <see cref="IPAddress" />. If an error occures, then
-        /// <see cref="IPAddress.None" /> is returned.
+        /// An instance of <see cref="IPAddress" /> containing the public IP address, or <see cref="IPAddress.None" /> if an error is
         /// encountered.
         /// </returns>
-        public static IPAddress GetPublicIPAddress(bool useHttps = false)
+        public static IPAddress GetPublicIPAddress(bool useHttps = true)
         {
-            string address = GetPublicAddress(useHttps);
-            IPAddress ipAddress;
-            if (!IPAddress.TryParse(address, out ipAddress))
+            if (!IPAddress.TryParse(GetPublicIPAddressString(useHttps), out IPAddress ipAddress))
             {
                 return IPAddress.None;
             }
+
             return ipAddress;
         }
+
     }
 }


### PR DESCRIPTION
Correctly disposes of the WebClient before control is returned to the caller.

useHttps now defaults to true, as it is more safe to use HTTPS by default.

Fixed typos in the XML documentation and improved it slightly.

Inlined many variables meaning code size is smaller and more efficient.

Corrected the naming of GetPublicAddress to GetPublicIPAddressString which fits in line with the other method named GetPublicIPAddress.

Modified tests to account for new method name, also inlined the variables in the test and used _discards where possible to clean everything up and make as efficient as possible.