### PR TITLE
Ipify.net covered all cases for API calls and converted project to .netstandard 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Ipify.NET
 
-**An unofficial client library for `ipify <http://www.ipify.org>`: *A Simple IP Address API*.**
+more .NET version support added
+
+<img width="871" height="440" alt="image" src="https://github.com/user-attachments/assets/e38d2e31-4b87-4661-94ff-ce05356f5adb" />
+
+
+**.NET client library for `ipify <http://www.ipify.org>`: *A Simple IP Address API*.**
 
 ##Meta
 
@@ -37,6 +42,11 @@ class Program
 ##Change Log
 
 All library changes, in descending order.
+
+####Version 2.0.0
+**Release Aug 14, 2025**
+- Ipify.net covered all cases for API calls and converted project to .netstandard 2.0
+- Nuget package release added
 
 ####Version 1.0.0
 

--- a/src/Ipify.Core/IpType.cs
+++ b/src/Ipify.Core/IpType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ipify.Net
+{
+    public enum IpType
+    {
+        /// <summary>
+        /// The api6.ipify.org is used for IPv6 request only. If you don't have an IPv6 address, the request will fail.
+        /// </summary>
+        IPv6,
+        /// <summary>
+        /// The api.ipify.org is used for IPv4 request only.
+        /// </summary>
+        IPv4,
+        /// <summary>
+        /// It will return either IPv4 or IPv6 IP
+        /// </summary>
+        Universal
+    }
+}

--- a/src/Ipify.Core/Ipify.Net.csproj
+++ b/src/Ipify.Core/Ipify.Net.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Ipify.NET A Simple IP Address API</Description>
+    <PackageProjectUrl>https://github.com/nitinjs/Ipify.NET</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/nitinjs/Ipify.NET</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>Ipify.NET A Simple IP Address API</Title>
+  </PropertyGroup>
+
+</Project>

--- a/src/Ipify.Core/Ipify.cs
+++ b/src/Ipify.Core/Ipify.cs
@@ -1,0 +1,88 @@
+﻿/*
+    Copyright © 2015 David Musgrove.
+    Licensed under the terms of the MIT License.
+*/
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Ipify.Net
+{
+    /// <summary>
+    /// Static utility class exposing methods to facilitate resolving a client's
+    /// public IP address on the Internet by querying the service at ipify.org.
+    /// </summary>
+    public static class Ipify
+    {
+        /// <summary>
+        /// Resolves the public IP address and returns it as a string.
+        /// </summary>
+        /// <param name="iptype">Type of IP: IPv6 or IPv4 or Universal</param>
+        /// <param name="responseType">Type of response: text, json or jsonp</param>
+        /// <param name="useHttps">Whether to use https when calling ipify API</param>
+        /// <param name="jsonpCallback">jsonp callback function in case of jsonp reponse type</param>
+        /// <returns></returns>
+        public async static Task<string> GetPublicAddress(IpType iptype = IpType.IPv4, ResponseType responseType = ResponseType.Text, bool useHttps = false, string jsonpCallback = "")
+        {
+            string subdomain = string.Empty;
+            switch (iptype)
+            {
+                case IpType.Universal:
+                    subdomain = "api64";
+                    break;
+                case IpType.IPv4:
+                    subdomain = "api";
+                    break;
+                case IpType.IPv6:
+                    subdomain = "api6";
+                    break;
+            }
+            var endpointURL = (useHttps ? "https://" : "http://") + $"{subdomain}.ipify.org/";
+            switch (responseType)
+            {
+                case ResponseType.Jsonp:
+                    endpointURL += "format=jsonp" + (string.IsNullOrWhiteSpace(jsonpCallback) ? "&callback=callback" : "");
+                    break;
+                case ResponseType.Json:
+                    endpointURL += "format=json";
+                    break;
+            }
+            var endpoint = useHttps ? "https://api.ipify.org" : "http://api.ipify.org";
+            HttpClient client = new HttpClient();
+            try
+            {
+                return await client.GetStringAsync(endpoint);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Resolves the public IP address and returns it as an instance of
+        /// <see cref="IPAddress" />.
+        /// </summary>
+        /// <param name="iptype">Type of IP: IPv6 or IPv4 or Universal</param>
+        /// <param name="responseType">Type of response: text, json or jsonp</param>
+        /// <param name="useHttps">Whether to use https when calling ipify API</param>
+        /// <param name="jsonpCallback">jsonp callback function in case of jsonp reponse type</param>
+        /// <returns>
+        /// An instance of <see cref="IPAddress" />. If an error occures, then
+        /// <see cref="IPAddress.None" /> is returned.
+        /// encountered.
+        /// </returns>
+        public async static Task<IPAddress> GetPublicIPAddress(IpType iptype = IpType.IPv4, ResponseType responseType = ResponseType.Text, bool useHttps = false, string jsonpCallback = "")
+        {
+            string address = await GetPublicAddress(iptype, responseType, useHttps, jsonpCallback);
+            IPAddress ipAddress;
+            if (!IPAddress.TryParse(address, out ipAddress))
+            {
+                return IPAddress.None;
+            }
+            return ipAddress;
+        }
+    }
+}

--- a/src/Ipify.Core/ResponseType.cs
+++ b/src/Ipify.Core/ResponseType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ipify.Net
+{
+    public enum ResponseType
+    {
+        Text,
+        Json,
+        Jsonp
+    }
+}

--- a/src/Ipify.NET.Tests/Ipify.NET.Tests/Ipify.NET.Tests.csproj
+++ b/src/Ipify.NET.Tests/Ipify.NET.Tests/Ipify.NET.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ipify.Core\Ipify.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ipify.NET.Tests/Ipify.NET.Tests/IpifyTests.cs
+++ b/src/Ipify.NET.Tests/Ipify.NET.Tests/IpifyTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using System.Net;
+using Ipify.Net;
+using System.Threading.Tasks;
+
+namespace Ipify.Net.Tests
+{
+    [TestFixture]
+    public class Tests
+    {
+        [Test]
+        public async Task GetAddress_ReturnsStringContainingAnIPAddress()
+        {
+            string ip = await Ipify.GetPublicAddress();
+            IPAddress ipAddress;
+            Assert.IsTrue(IPAddress.TryParse(ip, out ipAddress));
+        }
+
+        [Test]
+        public async Task GetAddress_ReturnsStringContainingAnIPAddressUsingHttps()
+        {
+            string ip = await Ipify.GetPublicAddress(useHttps: true);
+            IPAddress ipAddress;
+            Assert.IsTrue(IPAddress.TryParse(ip, out ipAddress));
+        }
+
+        [Test]
+        public async Task GetIPAddress_ReturnsIPAddressInstance()
+        {
+            IPAddress ipAddress = await Ipify.GetPublicIPAddress();
+            Assert.IsNotNull(ipAddress);
+            Assert.AreNotEqual(IPAddress.None, ipAddress);
+        }
+
+        [Test]
+        public async Task GetIPAddress_ReturnsIPAddressInstanceUsingHttps()
+        {
+            IPAddress ipAddress = await Ipify.GetPublicIPAddress(useHttps: true);
+            Assert.IsNotNull(ipAddress);
+            Assert.AreNotEqual(IPAddress.None, ipAddress);
+        }
+    }
+}

--- a/src/Ipify.sln
+++ b/src/Ipify.sln
@@ -1,11 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ipify", "Ipify\Ipify.csproj", "{3A76ED6C-03A7-4432-9187-CFF0CD97D53E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ipify.Tests", "Ipify.Tests\Ipify.Tests.csproj", "{A5A12BA3-3E1D-4B2D-BDCC-930A29836244}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ipify.Net", "Ipify.Core\Ipify.Net.csproj", "{56749004-A10B-C877-9E5E-2508D9B58361}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ipify.Net.Tests", "Ipify.NET.Tests\Ipify.NET.Tests\Ipify.Net.Tests.csproj", "{103ECC5B-9A74-4438-BCF5-196AC0A338B3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +25,19 @@ Global
 		{A5A12BA3-3E1D-4B2D-BDCC-930A29836244}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5A12BA3-3E1D-4B2D-BDCC-930A29836244}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5A12BA3-3E1D-4B2D-BDCC-930A29836244}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56749004-A10B-C877-9E5E-2508D9B58361}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56749004-A10B-C877-9E5E-2508D9B58361}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56749004-A10B-C877-9E5E-2508D9B58361}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56749004-A10B-C877-9E5E-2508D9B58361}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103ECC5B-9A74-4438-BCF5-196AC0A338B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103ECC5B-9A74-4438-BCF5-196AC0A338B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103ECC5B-9A74-4438-BCF5-196AC0A338B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103ECC5B-9A74-4438-BCF5-196AC0A338B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7149DDCF-7A6A-419B-9B42-BC0A503758F6}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Ipify.net 
- covered all cases for API calls
- converted project to .netstandard 2.0 so that it supports more versions of .net
- nuget package release configured